### PR TITLE
docs: update event catalog to current platform events

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ type Payload {
     "vehicle": {
       "id": "44dfd5cd-9f2f-449e-a5f5-769b5adfef34",
       "plate": "JDO8A24",
-      "type": "bus" // bus, truck, car, motorcycle, trailer, garbage_collector
+      "type": "bus" // bus, truck, car, motorcycle, trailer, garbage_collector, equipment
     },
     "driver": {
       "id": "6c466f6c-37d9-47a5-9c5c-98d9e4cf2ceb",
@@ -122,16 +122,16 @@ type Payload {
     "vehicle": {
       "id": "ac715b10-3142-4af2-bd91-08168723bd16",
       "plate": "PLA0001",
-      "type": "truck" // bus, truck, car, motorcycle, trailer, garbage_collector
+      "type": "truck" // bus, truck, car, motorcycle, trailer, garbage_collector, equipment
     },
     "attributes": {
-      // available for certain events when the device is a camera, this could be Null, this will be deprecated soon the `medias` is available
+      // DEPRECATED: use `medias` instead. Kept for backward compatibility, could be Null
       "media": {
         "camera": 1,
         "file_name": "EVENT_358735073823063_00000000_2024_01_26_20_15_06_51.mp4",
         "file_type": "mp4"
       },
-      // available for certain events when the device is a camera, this also could be Null, not available yet
+      // available for certain events when the device is a camera, this could be Null
       "medias": [
         {
           "camera": 1,
@@ -169,58 +169,92 @@ You should replace VEHICLE_ID, EVENT_ID, FILE_NAME with the values present insid
 
 ### Events
 
-| Slug name                | Has `is_initial` state attribute | Description                    |
-| ------------------------ | :------------------------------: | ------------------------------ |
-| `trailerOpen`            |               [ ]                | Abertura do baú                |
-| `cockpitDoorOpen`        |               [ ]                | Abertura da cabine             |
-| `hardAcceleration`       |               [ ]                | Aceleração brusca              |
-| `boardActivated`         |               [ ]                | Acionamento ativado            |
-| `boardDeactivated`       |               [ ]                | Acionamento desativado         |
-| `hardCornering`          |               [ ]                | Curva acentuada                |
-| `plugged`                |               [ ]                | Dispositivo conectado          |
-| `unplugged`              |               [ ]                | Dispositivo desconectado       |
-| `geofenceEnter`          |               [ ]                | Entrou na cerca                |
-| `deviceOverspeed`        |               [x]                | Excesso de velocidade          |
-| `routeOverspeed`         |               [x]                | Excesso de velocidade na via   |
-| `fault`                  |               [ ]                | Falha                          |
-| `cockpitDoorClose`       |               [ ]                | Fechamento da cabine           |
-| `hardBraking`            |               [ ]                | Frenagem brusca                |
-| `deviceMoving`           |               [ ]                | Movimento                      |
-| `deviceStopped`          |               [ ]                | Parada                         |
-| `geofenceExit`           |               [ ]                | Saiu da cerca                  |
-| `deviceOverweight`       |               [ ]                | Sobrepeso                      |
-| `driverChange`           |               [ ]                | Troca de motorista             |
-| `ignitionOff`            |               [ ]                | Veículo desligado              |
-| `ignitionOn`             |               [ ]                | Veículo ligado                 |
-| `deviceIdle`             |               [x]                | Veículo ocioso                 |
-| `simCardExceeded`        |               [ ]                | Excesso de tráfego no SIM Card |
-| `rebooting`              |               [ ]                | Restart                        |
-| `mainCameraError`        |               [ ]                | Erro câmera 1                  |
-| `secondaryCameraError`   |               [ ]                | Erro câmera 2                  |
-| `simCardError`           |               [ ]                | Erro no SIM Card               |
-| `powerCut`               |               [ ]                | Corte de energia               |
-| `newDriver`              |               [ ]                | Novo motorista                 |
-| `missingUSBCamera`       |               [ ]                | Sem câmera USB                 |
-| `collisionRisk`          |               [ ]                | Risco de colisão               |
-| `fuelCut`                |               [ ]                | Corte de combustível           |
-| `parkingMode`            |               [ ]                | Modo estacionamento            |
-| `missingDriver`          |               [ ]                | Sem motorista                  |
-| `recordActive`           |               [ ]                | Captura ativa                  |
-| `fatigue`                |               [ ]                | Fadiga                         |
-| `usingPhone`             |               [ ]                | Celular                        |
-| `smoking`                |               [ ]                | Fumo                           |
-| `distraction`            |               [ ]                | Distração                      |
-| `yawning`                |               [ ]                | Bocejo                         |
-| `requestedVideo`         |               [ ]                | Vídeo solicitado               |
-| `geofenceOverspeed`      |               [x]                | Excesso de velocidade na cerca |
-| `eyesClosed`             |               [ ]                | Olhos fechados                 |
-| `lookingDown`            |               [ ]                | Olhou para baixo               |
-| `cameraCovered`          |               [ ]                | Câmera coberta                 |
-| `memoryCardFull`         |               [ ]                | Cartão de memória cheio        |
-| `noMemoryCard`           |               [ ]                | Sem cartão de memória          |
-| `lowVoltage`             |               [ ]                | Bateria baixa                  |
-| `stoppedOutsideGeofence` |               [ ]                | Parada fora da cerca           |
+The table below reflects the current event catalog of the platform. The actual
+set of events your organization receives depends on the equipment installed in
+each vehicle (tracker, camera, DMS/ADAS support, CAN bus).
 
+#### Telemetry
+
+| Slug name            | Has `is_initial` state attribute | Description                    |
+| -------------------- | :------------------------------: | ------------------------------ |
+| `trailerOpen`        |               [ ]                | Abertura do baú                |
+| `cockpitDoorOpen`    |               [ ]                | Abertura da cabine             |
+| `cockpitDoorClose`   |               [ ]                | Fechamento da cabine           |
+| `geofenceEnter`      |               [ ]                | Entrou na cerca                |
+| `geofenceExit`       |               [ ]                | Saiu da cerca                  |
+| `ignitionOn`         |               [ ]                | Veículo ligado                 |
+| `ignitionOff`        |               [ ]                | Veículo desligado              |
+| `deviceOnline`       |               [ ]                | Equipamento conectado          |
+| `deviceOffline`      |               [ ]                | Equipamento desconectado       |
+| `deviceStopped`      |               [ ]                | Parada / Parada fora da cerca  |
+| `deviceMoving`       |               [ ]                | Movimento                      |
+| `deviceOverspeed`    |               [x]                | Excesso de velocidade          |
+| `routeOverspeed`     |               [x]                | Excesso de velocidade na via   |
+| `geofenceOverspeed`  |               [x]                | Excesso de velocidade na cerca |
+| `deviceIdle`         |               [x]                | Marcha lenta excessiva         |
+| `deviceOverweight`   |               [ ]                | Sobrepeso                      |
+| `boardActivated`     |               [ ]                | Acionamento ativado            |
+| `boardDeactivated`   |               [ ]                | Acionamento desativado         |
+| `plugged`            |               [ ]                | Dispositivo conectado          |
+| `hardAcceleration`   |               [ ]                | Aceleração brusca              |
+| `hardBraking`        |               [ ]                | Frenagem brusca                |
+| `hardCornering`      |               [ ]                | Curva acentuada                |
+
+#### Camera / video telemetry
+
+| Slug name         | Has `is_initial` state attribute | Description             |
+| ----------------- | :------------------------------: | ----------------------- |
+| `cameraCovered`   |               [ ]                | Câmera coberta          |
+| `memoryCardFull`  |               [ ]                | Cartão de memória cheio |
+| `noMemoryCard`    |               [ ]                | Sem cartão de memória   |
+| `lowVoltage`      |               [ ]                | Bateria baixa           |
+| `powerCut`        |               [ ]                | Bloqueio do veículo     |
+| `requestedVideo`  |               [ ]                | Vídeo solicitado        |
+| `unplugged`       |               [ ]                | Dispositivo removido    |
+| `missingDriver`   |               [ ]                | Sem motorista           |
+
+#### DMS (driver monitoring)
+
+| Slug name         | Has `is_initial` state attribute | Description           |
+| ----------------- | :------------------------------: | --------------------- |
+| `fatigue`         |               [ ]                | Fadiga                |
+| `usingPhone`      |               [ ]                | Celular               |
+| `smoking`         |               [ ]                | Fumo                  |
+| `distraction`     |               [ ]                | Distração             |
+| `yawning`         |               [ ]                | Bocejo                |
+| `lookingDown`     |               [ ]                | Olhou para baixo      |
+| `eyesClosed`      |               [ ]                | Olhos fechados        |
+| `faceRecognition` |               [ ]                | Reconhecimento facial |
+
+#### ADAS
+
+| Slug name          | Has `is_initial` state attribute | Description                      |
+| ------------------ | :------------------------------: | -------------------------------- |
+| `laneDeparture`    |               [ ]                | Mudança de faixa                 |
+| `forwardCollision` |               [ ]                | Risco de colisão                 |
+| `vehicleTooClose`  |               [ ]                | Proximidade do veículo dianteiro |
+| `seatbeltUnbuckled`|               [ ]                | Sem cinto de segurança           |
+| `videoLoss`        |               [ ]                | Perda de vídeo                   |
+| `rollover`         |               [ ]                | Capotamento                      |
+
+#### CAN bus
+
+| Slug name         | Has `is_initial` state attribute | Description             |
+| ----------------- | :------------------------------: | ----------------------- |
+| `rpmRedLane`      |               [x]                | Faixa vermelha de RPM   |
+| `rpmCoastingLane` |               [x]                | Movimentação em banguela|
+
+Events flagged with `is_initial` are delivered in pairs: one message marking
+the start (`is_initial: true`) and one marking the end (`is_initial: false`).
 When the event does have the attribute `is_initial` and the value is equal to `false`,
 the event payload will have some additional information, like: `duration`, `distance`,
 `avg_speed`, `max_speed`. The most common filled is `duration`.
+
+#### Removed events
+
+The following slugs were part of older versions of this catalog and are no
+longer emitted by the platform: `collisionRisk` (replaced by `forwardCollision`),
+`driverChange`, `newDriver`, `fault`, `fuelCut`, `mainCameraError`,
+`secondaryCameraError`, `missingUSBCamera`, `recordActive`, `rebooting`,
+`simCardError`, `simCardExceeded`, `parkingMode` and `stoppedOutsideGeofence`
+(replaced by `deviceStopped` outside a geofence).

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,9 @@ export type EventAttributes = {
   original_type?: string;
   unique_id?: string;
   is_initial?: boolean;
-  geofence_name?: string;
+  geofence_name?: string | null;
+  /** @deprecated Use `medias` instead. Kept for backward compatibility. */
+  media?: EventMedia | null;
   medias?: EventMedia[] | null;
   [key: string]: any;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,16 +65,25 @@ export type Event = {
   attributes: EventAttributes;
 };
 
+export type EventMedia = {
+  camera: number;
+  file_name: string;
+  file_type: string;
+};
+
 export type EventAttributes = {
   speed: number;
   course: number;
   original_type?: string;
   unique_id?: string;
+  is_initial?: boolean;
+  geofence_name?: string;
+  medias?: EventMedia[] | null;
   [key: string]: any;
 };
 
 export enum EventSlugNameEnum {
-  driverChange = "driverChange",
+  // Telemetry
   trailerOpen = "trailerOpen",
   cockpitDoorOpen = "cockpitDoorOpen",
   cockpitDoorClose = "cockpitDoorClose",
@@ -82,17 +91,47 @@ export enum EventSlugNameEnum {
   geofenceExit = "geofenceExit",
   ignitionOn = "ignitionOn",
   ignitionOff = "ignitionOff",
+  deviceOnline = "deviceOnline",
+  deviceOffline = "deviceOffline",
   deviceStopped = "deviceStopped",
   deviceMoving = "deviceMoving",
   deviceOverspeed = "deviceOverspeed",
   routeOverspeed = "routeOverspeed",
-  hardBraking = "hardBraking",
-  fault = "fault",
-  hardCornering = "hardCornering",
-  hardAcceleration = "hardAcceleration",
+  geofenceOverspeed = "geofenceOverspeed",
+  deviceIdle = "deviceIdle",
   deviceOverweight = "deviceOverweight",
   boardActivated = "boardActivated",
   boardDeactivated = "boardDeactivated",
-  unplugged = "unplugged",
   plugged = "plugged",
+  hardAcceleration = "hardAcceleration",
+  hardBraking = "hardBraking",
+  hardCornering = "hardCornering",
+  // Camera / video telemetry
+  cameraCovered = "cameraCovered",
+  memoryCardFull = "memoryCardFull",
+  noMemoryCard = "noMemoryCard",
+  lowVoltage = "lowVoltage",
+  powerCut = "powerCut",
+  requestedVideo = "requestedVideo",
+  unplugged = "unplugged",
+  missingDriver = "missingDriver",
+  // DMS (driver monitoring)
+  fatigue = "fatigue",
+  usingPhone = "usingPhone",
+  smoking = "smoking",
+  distraction = "distraction",
+  yawning = "yawning",
+  lookingDown = "lookingDown",
+  eyesClosed = "eyesClosed",
+  faceRecognition = "faceRecognition",
+  // ADAS
+  laneDeparture = "laneDeparture",
+  forwardCollision = "forwardCollision",
+  vehicleTooClose = "vehicleTooClose",
+  seatbeltUnbuckled = "seatbeltUnbuckled",
+  videoLoss = "videoLoss",
+  rollover = "rollover",
+  // CAN bus
+  rpmRedLane = "rpmRedLane",
+  rpmCoastingLane = "rpmCoastingLane",
 }


### PR DESCRIPTION
## Motivation

The event catalog in this repo hasn't been updated since jul/2024 and no longer matches the platform's current catalog. Customers use this README as an integration reference: ADAS events such as `laneDeparture` and `vehicleTooClose` exist on the platform but were missing here, while 14 listed slugs are no longer emitted.

## Changes

- **Add missing events**: deviceOnline/deviceOffline, geofenceOverspeed, deviceIdle, camera events (cameraCovered, memoryCardFull, noMemoryCard, lowVoltage, powerCut, requestedVideo, missingDriver), DMS (fatigue, usingPhone, smoking, distraction, yawning, lookingDown, eyesClosed, faceRecognition), ADAS (laneDeparture, forwardCollision, vehicleTooClose, seatbeltUnbuckled, videoLoss, rollover) and CAN bus (rpmRedLane, rpmCoastingLane).
- **Remove slugs no longer emitted** and document the migration in a "Removed events" section: collisionRisk (→ forwardCollision), driverChange, newDriver, fault, fuelCut, mainCameraError, secondaryCameraError, missingUSBCamera, recordActive, rebooting, simCardError, simCardExceeded, parkingMode, stoppedOutsideGeofence (→ deviceStopped outside a geofence).
- Group the catalog by equipment capability (Telemetry / Camera / DMS / ADAS / CAN bus) and flag the start/end pairs (`is_initial`): deviceOverspeed, routeOverspeed, geofenceOverspeed, deviceIdle, rpmRedLane, rpmCoastingLane.
- Mark `attributes.media` (singular) as deprecated in favor of `medias`, which is available.
- Add `equipment` to the `vehicle.type` examples.
- Update `EventSlugNameEnum` and type `medias`, `is_initial` and `geofence_name` in `EventAttributes`.

`npx tsc --noEmit` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos recursos**
  * Ampliado o suporte a eventos de telemetria, câmera, vídeo, DMS, ADAS e CAN bus.
  * Adicionados dados de mídia, status inicial do evento e nome da geofence nas informações recebidas.
  * Incluídos novos tipos de eventos, como dispositivos online, offline, parados e ociosos.

* **Documentação**
  * Atualizados exemplos de payloads e tabelas de eventos disponíveis.
  * Identificado `attributes.media` como obsoleto, com recomendação de uso de `medias`.
  * Documentados eventos removidos e suas substituições correspondentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->